### PR TITLE
Allow creation of Nextcloud admin user

### DIFF
--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -114,7 +114,8 @@ if [ ! -f /data/config/config.php ]; then
   # https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/automatic_configuration.html
   touch /tmp/first-install
   echo "Creating automatic configuration..."
-  cat > /var/www/config/autoconfig.php <<EOL
+  if [ -z "$NEXTCLOUD_ADMIN_USER" ]; then
+    cat > /var/www/config/autoconfig.php <<EOL
 <?php
 \$AUTOCONFIG = array(
     'directory' => '/data/data',
@@ -126,6 +127,22 @@ if [ ! -f /data/config/config.php ]; then
     'dbtableprefix' => '',
 );
 EOL
+  else
+  cat > /var/www/config/autoconfig.php <<EOL
+<?php
+\$AUTOCONFIG = array(
+    'directory' => '/data/data',
+    'dbtype' => '${DB_TYPE}',
+    'dbname' => '${DB_NAME}',
+    'dbuser' => '${DB_USER}',
+    'dbpass' => '${DB_PASSWORD}',
+    'dbhost' => '${DB_HOST}',
+    'dbtableprefix' => '',
+    'adminlogin'    => '${NEXTCLOUD_ADMIN_USER}',
+    'adminpass'     => '${NEXTCLOUD_ADMIN_PASSWORD}',
+);
+EOL
+  fi
   runas_user cat > /data/config/config.php <<EOL
 <?php
 \$CONFIG = array(


### PR DESCRIPTION
By using the default next cloud variables; NEXTCLOUD_ADMIN_USER and NEXTCLOUD_ADMIN_PASSWORD; we may now create the admin user so that the nextcloud instance is fully ready on the first launch.