### PR TITLE
Change X-Robots-Tag value to "noindex, nofollow"

### DIFF
--- a/rootfs/tpls/etc/nginx/nginx.conf
+++ b/rootfs/tpls/etc/nginx/nginx.conf
@@ -84,7 +84,7 @@ http {
         add_header X-Download-Options "noopen" always;
         add_header X-Frame-Options "@XFRAME_OPTS_HEADER@" always;
         add_header X-Permitted-Cross-Domain-Policies "none" always;
-        add_header X-Robots-Tag "none" always;
+        add_header X-Robots-Tag "noindex, nofollow" always;
         add_header X-XSS-Protection "1; mode=block" always;
 
         # Remove X-Powered-By, which is an information leak
@@ -169,7 +169,7 @@ http {
             add_header X-Download-Options "noopen" always;
             add_header X-Frame-Options "@XFRAME_OPTS_HEADER@" always;
             add_header X-Permitted-Cross-Domain-Policies "none" always;
-            add_header X-Robots-Tag "none" always;
+            add_header X-Robots-Tag "noindex, nofollow" always;
             add_header X-XSS-Protection "1; mode=block" always;
             access_log off;
       


### PR DESCRIPTION
According to a merged Nextcloud server PR (https://github.com/nextcloud/server/pull/36689), "none" might not be equivalent to "noindex, nofollow" for some search engines and was adjusted in the server code accordingly. This PR modifies the nginx config to be in line with that change.