### PR TITLE
nginx: remove ocm-provider handling

### DIFF
--- a/rootfs/tpls/etc/nginx/nginx.conf
+++ b/rootfs/tpls/etc/nginx/nginx.conf
@@ -139,7 +139,7 @@ http {
             deny all;
         }
 
-        location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy)\.php(?:$|\/) {
+        location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+|.+\/richdocumentscode\/proxy)\.php(?:$|\/) {
             fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
             set $path_info $fastcgi_path_info;
             try_files $fastcgi_script_name =404;
@@ -155,7 +155,7 @@ http {
             fastcgi_read_timeout 1200;
         }
 
-        location ~ ^\/(?:updater|oc[ms]-provider)(?:$|\/) {
+        location ~ ^\/(?:updater|ocs-provider)(?:$|\/) {
             try_files $uri/ =404;
             index index.php;
         }
@@ -172,7 +172,7 @@ http {
             add_header X-Robots-Tag "noindex, nofollow" always;
             add_header X-XSS-Protection "1; mode=block" always;
             access_log off;
-      
+
             location ~ \.wasm$ {
                 default_type application/wasm;
             }


### PR DESCRIPTION
Fixes error:

```
Your web server is not properly set up to resolve "/ocm-provider/"
```