### PR TITLE
Fix missing caching_sha2_password.so library

### DIFF
--- a/Dockerfile-27
+++ b/Dockerfile-27
@@ -30,6 +30,7 @@ RUN apk --update --no-cache add \
     ghostscript \
     libxml2 \
     mysql-client \
+    mariadb-connector-c \
     nginx \
     openssl \
     php83 \

--- a/Dockerfile-28
+++ b/Dockerfile-28
@@ -30,6 +30,7 @@ RUN apk --update --no-cache add \
     ghostscript \
     libxml2 \
     mysql-client \
+    mariadb-connector-c \
     nginx \
     openssl \
     php83 \

--- a/Dockerfile-29
+++ b/Dockerfile-29
@@ -31,6 +31,7 @@ RUN apk --update --no-cache add \
     ghostscript \
     libxml2 \
     mysql-client \
+    mariadb-connector-c \
     nginx \
     openssl \
     php83 \


### PR DESCRIPTION
Fix missing caching_sha2_password when connect to mysql db version >= 8.4

```
admin@XXXX:$ docker exec -it nextcloud bash
75334fa4b046:/var/www# mysql -h mysql -u nextcloud1 -pXXXXXXX
ERROR 1045 (28000): Plugin caching_sha2_password could not be loaded: Error loading shared library /usr/lib/mariadb/plugin/caching_sha2_password.so: No such file or directory
75334fa4b046:/var/www#
admin@XXXXX:$ docker exec -it nextcloud bash
75334fa4b046:/var/www# apk add mariadb-connector-c
fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
(1/1) Installing mariadb-connector-c (3.3.10-r0)
OK: 447 MiB in 303 packages
75334fa4b046:/var/www# mysql -h mysql -u nextcloud1 -pXXXXXXX
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MySQL connection id is 5975
Server version: 9.0.0 MySQL Community Server - GPL
```